### PR TITLE
add yapf format checker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,14 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install mypy
+        pip install yapf
     - name: Check types with mypy
       # Get all files with find because ** doesn't expand correctly.
       run: |
         find . -iname '*.py' | xargs mypy
+    - name: Check formatting with yapf
+      run: |
+        yapf --diff --recursive .
     - name: Test with unittest
       run: |
         python -m unittest

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-show_error_codes = True
-disallow_untyped_defs = True

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Runs queries to recreate any tables derived from the base tables.
 
 ## Testing
 
+All tests and lint checks will be run on pull requests using
+[github actions](https://github.com/Jigsaw-Code/censoredplanet-analysis/actions)
+
 To run all tests run
 
 `python -m unittest`
@@ -83,4 +86,6 @@ To typecheck all files install mypy and run
 
 `mypy **/*.py`
 
-This produces some spurious errors because of missing types in dependencies
+To format all files install yapf and run
+
+`yapf --in-place --recursive .`

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ To run all tests run
 
 `python -m unittest`
 
-To typecheck all files install mypy and run
+To typecheck all files install `mypy` and run
 
 `mypy **/*.py`
 
-To format all files install yapf and run
+To format all files install `yapf` and run
 
 `yapf --in-place --recursive .`

--- a/pipeline/beam_tables.py
+++ b/pipeline/beam_tables.py
@@ -211,9 +211,8 @@ def _read_scan_text(
 
   # PCollection[Tuple[filename,line]]
   lines = (
-      tuple(line_pcollections_per_file)
-      | 'flatten lines' >> beam.Flatten(pipeline=p).with_output_types(
-          Tuple[str, str]))
+      tuple(line_pcollections_per_file) | 'flatten lines' >>
+      beam.Flatten(pipeline=p).with_output_types(Tuple[str, str]))
 
   return lines
 
@@ -553,15 +552,14 @@ class ScanDataBeamPipelineRunner():
 
     # PCollection[Tuple[DateIpKey,Row]]
     rows_keyed_by_ip_and_date = (
-        rows
-        | 'key by ips and dates' >>
+        rows | 'key by ips and dates' >>
         beam.Map(lambda row: (_make_date_ip_key(row), row)).with_output_types(
             Tuple[DateIpKey, Row]))
 
     # PCollection[DateIpKey]
     ips_and_dates = (
-        rows_keyed_by_ip_and_date
-        | 'get keys' >> beam.Keys().with_output_types(DateIpKey))
+        rows_keyed_by_ip_and_date | 'get ip and date keys per row' >>
+        beam.Keys().with_output_types(DateIpKey))
 
     # PCollection[DateIpKey]
     deduped_ips_and_dates = (
@@ -574,8 +572,7 @@ class ScanDataBeamPipelineRunner():
 
     # PCollection[Tuple[DateIpKey,Row]]
     ips_with_metadata = (
-        grouped_ips_by_dates
-        | 'get ip metadata' >> beam.FlatMapTuple(
+        grouped_ips_by_dates | 'get ip metadata' >> beam.FlatMapTuple(
             self._add_ip_metadata).with_output_types(Tuple[DateIpKey, Row]))
 
     # PCollection[Tuple[Tuple[date,ip],Dict[input_name_key,List[Row]]]]
@@ -586,8 +583,7 @@ class ScanDataBeamPipelineRunner():
 
     # PCollection[Row]
     rows_with_metadata = (
-        grouped_metadata_and_rows
-        | 'merge metadata with rows' >>
+        grouped_metadata_and_rows | 'merge metadata with rows' >>
         beam.FlatMapTuple(_merge_metadata_with_rows).with_output_types(Row))
 
     return rows_with_metadata

--- a/pipeline/metadata/test_ip_metadata.py
+++ b/pipeline/metadata/test_ip_metadata.py
@@ -27,12 +27,12 @@ class IpMetadataTest(unittest.TestCase):
 
   def test_parse_asn_db(self) -> None:
     # Sample content for a routeviews-rv2-*.pfx2as file
-    # pyformat: disable
+    # yapf: disable
     routeview_file_content = iter([
         "1.0.0.0\t24\t13335",
         "8.8.8.0\t24\t15169",
     ])
-    # pyformat: enable
+    # yapf: enable
     asn_db = ip_metadata._parse_asn_db(routeview_file_content)
 
     self.assertEqual(asn_db.lookup("1.0.0.1"), (13335, "1.0.0.0/24"))
@@ -40,7 +40,7 @@ class IpMetadataTest(unittest.TestCase):
 
   def test_parse_org_map(self) -> None:
     # Sample content for an as-org2info.txt file.
-    # pyformat: disable
+    # yapf: disable
     as2org_file_content = iter([
         "# name: AS Org",
         "# some random",
@@ -53,7 +53,7 @@ class IpMetadataTest(unittest.TestCase):
         "19864|20120320|O1COMM|01CO-ARIN|928772fc737205dea9e069438acaae36_ARIN|ARIN",
         "394811|20160111|O1FIBER|01CO-ARIN|928772fc737205dea9e069438acaae36_ARIN|ARIN"
     ])
-    # pyformat: enable
+    # yapf: enable
 
     as2org_map = ip_metadata._parse_as_to_org_map(as2org_file_content)
     self.assertEqual(
@@ -65,7 +65,7 @@ class IpMetadataTest(unittest.TestCase):
 
   def test_parse_as_to_type_map(self) -> None:
     # Sample content for an as2types.txt file
-    # pyformat: disable
+    # yapf: disable
     as2type_file_content = iter([
         "# format: as|source|type",
         "# date: 20201001",
@@ -76,7 +76,7 @@ class IpMetadataTest(unittest.TestCase):
         "1|CAIDA_class|Transit/Access",
         "4|CAIDA_class|Content"
     ])
-    # pyformat: enable
+    # yapf: enable
 
     as2type_map = ip_metadata._parse_as_to_type_map(as2type_file_content)
     self.assertEqual(as2type_map, {1: "Transit/Access", 4: "Content"})

--- a/pipeline/test_beam_tables.py
+++ b/pipeline/test_beam_tables.py
@@ -157,7 +157,7 @@ class PipelineMainTest(unittest.TestCase):
     self.assertListEqual(flat_headers, expected_headers)
 
   def test_parse_received_data_http(self) -> None:
-    # pyformat: disable
+    # yapf: disable
     received = {
         'status_line': '403 Forbidden',
         'headers': {},
@@ -169,13 +169,13 @@ class PipelineMainTest(unittest.TestCase):
         'received_body': '<html><head><meta http-equiv="Content-Type" content="text/html; charset=windows-1256"><title>MNN3-1(1)</title></head><body><iframe src="http://10.10.34.35:80" style="width: 100%; height: 100%" scrolling="no" marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0"></iframe></body></html>\r\n\r\n',
         'received_headers': []
     }
-    # pyformat: enable
+    # yapf: enable
 
     parsed = beam_tables._parse_received_data(received)
     self.assertDictEqual(parsed, expected)
 
   def test_parse_received_data_no_header_field(self) -> None:
-    # pyformat: disable
+    # yapf: disable
     received = {
         'status_line': '403 Forbidden',
         'body': '<test-body>'
@@ -187,13 +187,13 @@ class PipelineMainTest(unittest.TestCase):
         'received_body': '<test-body>',
         'received_headers': []
     }
-    # pyformat: enable
+    # yapf: enable
 
     parsed = beam_tables._parse_received_data(received)
     self.assertDictEqual(parsed, expected)
 
   def test_parse_received_data_https(self) -> None:
-    # pyformat: disable
+    # yapf: disable
     received = {
         'status_line': '403 Forbidden',
         'headers': {
@@ -231,7 +231,7 @@ class PipelineMainTest(unittest.TestCase):
             'Set-Cookie: bm_sz=6A1BDB4DFCA371F55C598A6D50C7DC3F~YAAQtTXdWKzJ+ZR1AQAA6zY7nwmc3d1xb2D5pqi3WHoMGfNsB8zB22LP5Kz/15sxdI3d3qznv4NzhGdb6CjijzFezAd18NREhybEvZMSZe2JHkjBjli/y1ZRMgC512ln7CCHURjS03UWDIzVrpwPV3Z/h/mq00NF2+LgHsDPelEZoArYVmEwH7OtE4zHAePErKw=; Domain=.discover.com; Path=/; Expires=Sat, 07 Nov 2020 00:24:19 GMT; Max-Age=14400; HttpOnly_abck=7A29878FA7120EC680C6E591A8FF3F5A~-1~YAAQtTXdWK3J+ZR1AQAA6zY7nwR93cThkIxWHn0icKtS6Wgb6NVHSQ80nZ6I2DzczA+1qn/0rXSGZUcFvW/+7tmDF0lHsieeRwnmIydhPELwAsNLjfBMF1lJm9Y7u4ppUpD4WtbRJ1g+Qhd9CLcelH3fQ8AVmJn/jRNN8WrisA8GKuUhpfjv9Gp1aGGqzv12H8u3Ogt/9oOv4Y8nKuS7CWipsFuPftCMeTBVbPn/JsV/NzttmkuFikLj8PwmpNecqlhaH1Ra32XDl/hVsCFWaPm4wdWO3d2WDK8Em0sHzklyTV4iFo6itVlCEHQ=~-1~-1~-1; Domain=.discover.com; Path=/; Expires=Sat, 06 Nov 2021 20:24:19 GMT; Max-Age=31536000; Secure'
         ],
     }
-    # pyformat: enable
+    # yapf: enable
 
     parsed = beam_tables._parse_received_data(received)
     self.assertDictEqual(parsed, expected)
@@ -459,7 +459,7 @@ class PipelineMainTest(unittest.TestCase):
     """
     filename = 'gs://firehook-scans/http/CP_Quack-https-2020-11-06-15-15-31/results.json'
 
-    # pyformat: disable
+    # yapf: disable
     expected_row: beam_tables.Row = {
         'domain': 'www.arabhra.org',
         'ip': '213.175.166.157',
@@ -492,7 +492,7 @@ class PipelineMainTest(unittest.TestCase):
         'measurement_id': '',
         'source': 'CP_Quack-https-2020-11-06-15-15-31',
     }
-    # pyformat: enable
+    # yapf: enable
 
     row = list(beam_tables._flatten_measurement(filename, line))[0]
     # We can't test the measurement id because it's random

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[mypy]
+ignore_missing_imports = True
+show_error_codes = True
+disallow_untyped_defs = True
+
+[yapf]
+based_on_style = google
+indent_width = 2
+column_limit = 80
+split_before_expression_after_opening_paren = True


### PR DESCRIPTION
Add yapf formatting checks as a github action. Match the same style I'm getting internally with pyformat.

I did have to change a few lines in beam_tables.py that use `( ... | ... >> ... )` syntax. pyformat allows multiple formats for these lines, while yapf is stricter.

example action passing yapf check: https://github.com/Jigsaw-Code/censoredplanet-analysis/runs/1483048671?check_suite_focus=true