### PR TITLE
switch away from using httpio to get routeview files

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ command
 
 To typecheck all files install `mypy` and run
 
-`mypy **/*.py`
+`mypy **/*.py --namespace-packages --explicit-package-bases`
 
 To format all files install `yapf` and run
 

--- a/mirror/routeviews/bulk_download.py
+++ b/mirror/routeviews/bulk_download.py
@@ -14,9 +14,9 @@
 """Bulk importer for CAIDA routeview files."""
 
 import datetime
+import urllib.request
 
 import requests
-import urllib.request
 
 from google.cloud import storage
 

--- a/mirror/routeviews/bulk_download.py
+++ b/mirror/routeviews/bulk_download.py
@@ -15,8 +15,8 @@
 
 import datetime
 
-import httpio
 import requests
+import urllib
 
 from google.cloud import storage
 
@@ -67,12 +67,12 @@ def download_days_routeview(bucket: storage.bucket.Bucket,
       # This call will fail for most urls,
       # since we don't know which timestamp is correct.
       # In that case we just move on to our next guess.
-      f = httpio.open(url)
+      content = urllib.request.urlopen(url).read()
 
       print(f"mirroring {url} to gs://{bucket.name}/{cloud_filepath}")
 
       blob = bucket.blob(cloud_filepath)
-      blob.upload_from_file(f)
+      blob.upload_from_string(content)
     except requests.exceptions.HTTPError as ex:
       if ex.response.status_code != 404:
         raise ex

--- a/mirror/routeviews/bulk_download.py
+++ b/mirror/routeviews/bulk_download.py
@@ -16,7 +16,7 @@
 import datetime
 
 import requests
-import urllib
+import urllib.request
 
 from google.cloud import storage
 

--- a/mirror/routeviews/sync_routeviews.py
+++ b/mirror/routeviews/sync_routeviews.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 """Mirror the latest CAIDA routeview files into a cloud bucket."""
 
-import io
 import os
 import pathlib
 from pprint import pprint
 from typing import List
+import urllib.request
 
 from google.cloud import storage
-import urllib.request
 
 import firehook_resources
 

--- a/mirror/routeviews/sync_routeviews.py
+++ b/mirror/routeviews/sync_routeviews.py
@@ -19,8 +19,8 @@ import pathlib
 from pprint import pprint
 from typing import List
 
-import httpio
 from google.cloud import storage
+import urllib
 
 import firehook_resources
 
@@ -39,7 +39,8 @@ def _get_latest_generated_routeview_files() -> List[str]:
         "routeviews-rv2-20200719-1200.pfx2as.gz"]
   """
   url = CAIDA_ROUTEVIEW_DIR_URL + CAIDA_CREATION_FILE
-  output = io.TextIOWrapper(httpio.open(url), encoding="utf-8")
+  output = map(lambda line: line.decode('utf8').rstrip(),
+               urllib.request.urlopen(url).readlines())
 
   files = []
   for line in output:
@@ -92,8 +93,8 @@ class RouteviewMirror():
     output_blob = self.caida_bucket.blob(
         os.path.join(self.bucket_routeview_path, filename))
 
-    with httpio.open(url) as output:
-      output_blob.upload_from_file(output)
+    output = urllib.request.urlopen(url).read()
+    output_blob.upload_from_string(output)
 
   def sync(self) -> None:
     """Look for new routeview files and transfer them into the cloud bucket."""

--- a/mirror/routeviews/sync_routeviews.py
+++ b/mirror/routeviews/sync_routeviews.py
@@ -20,7 +20,7 @@ from pprint import pprint
 from typing import List
 
 from google.cloud import storage
-import urllib
+import urllib.request
 
 import firehook_resources
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ google-cloud-bigquery==1.28.0
 google-cloud-storage==1.32.0
 # Specify resumable-media version to avoid dependency conflict
 google-resumable-media===1.1.0
-httpio==0.3.0
 pyasn==1.6.1
 requests==2.24.0
 retry==0.9.2


### PR DESCRIPTION
Caida's routeview files have stopped providing the http "length" property, so we started getting errors like 

> HTTPIOError("Server does not report content length")

which broke the pipeline.

[HTTPIO](https://github.com/barneygale/httpio) relies on knowing the content length to download the file in a streaming way and implement the `seek()` method, which allowed us to treat the object as a file for GCS upload purposes. This PR switches to using vanilla `urllib` and `upload_as_string`.

This is more memory-intensive since it requires reading the routeview files into memory, but they aren't very big, (~3mb per file) so it doesn't seem worth it to fight with whatever changed on the CAIDA side.