### PR TITLE
add error reporting to the pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ google-apitools==0.5.31
 google-api-python-client==1.12.8
 google-api-python-client-stubs==0.3.0
 google-cloud-bigquery==1.28.0
+google-cloud-error-reporting==1.1.0
 google-cloud-storage==1.32.0
 # Specify resumable-media version to avoid dependency conflict
 google-resumable-media===1.1.0


### PR DESCRIPTION
(currently branched off of another outstanding pr, but should be merged into master)

Currently when there are errors in the pipeline they are logged by https://console.cloud.google.com/logs/viewer but the errors/stacktraces aren't surfaced to https://console.cloud.google.com/errors.  This means if I'm not paying attention breakages go unnoticed.

This change adds logging to that console. Once we're logging there it will be easy for people to enable the built-in email notifications on new errors and notice problems more quickly.

If you go to https://console.cloud.google.com/errors?project=firehook-censoredplanet now you can see a test error I've logged using this change.