### PR TITLE
update table docs for error classification

### DIFF
--- a/docs/base_tables.md
+++ b/docs/base_tables.md
@@ -1,0 +1,98 @@
+# Base Tables
+
+These tables are created using the original censored planet json data, plus some
+[additional data sources](../pipeline/metadata/).
+
+## Table names
+
+There is one table for each scan type.
+
+- `firehook-censoredplanet:base.echo_scan`
+- `firehook-censoredplanet:base.discard_scan`
+- `firehook-censoredplanet:base.http_scan`
+- `firehook-censoredplanet:base.https_scan`
+
+## Partitioning and Clustering
+
+The tables are time-partitioned along the `date` field.
+
+The tables are clustered along the `country` and then `asn` fields.
+
+## Original Data Format
+
+The Censored Planet data is stored in .json files with one measurement per line.
+The measurements look like this:
+
+```
+{ "Server": "1.1.1.1",
+  "Keyword": "example.com",
+  "Retries": 4,
+  "Results": [
+    {
+      "Sent": "GET / HTTP/1.1 Host: example.com",
+      "Received": "HTTP/1.1 503 Service Unavailable",
+      "Success": false,
+      "Error": "Incorrect echo response",
+      "StartTime": "2020-04-29T07:29:46.139500633-04:00",
+      "EndTime": "2020-04-29T07:29:46.490678827-04:00"
+    },
+    ...
+  ],
+  "Blocked": true,
+  "FailSanity": false,
+  "StatefulBlock": false
+}
+```
+
+## Table Format
+
+The json data is processed into a flat table format which looks like this.
+
+| Field Name                | Type         | Contains |
+| ------------------------- | ------------ | -------- |
+|                           |
+| **Measured Domain**       |
+|                           |
+| domain                    | STRING       | The domain being tested, eg. `example.com` |
+|                           |
+| **Vantage Point Server**  |
+|                           |
+| ip                        | STRING       | The ip address of the server being tested, eg. `1.1.1.1` |
+| netblock                  | STRING       | Netblock of the IP, eg. `1.1.1.0/24` |
+| asn                       | INTEGER      | Autonomous system number, eg. `13335` |
+| as_name                   | STRING       | Autonomous system short name, eg. `CLOUDFLARENET` |
+| as_full_name              | STRING       | Autonomous system long name, eg. `Cloudflare, Inc.` |
+| as_class                  | STRING       | The type of AS eg. `Transit/Access`, `Content` (for CDNs) or `Enterprise` |
+| country                   | STRING       | Autonomous system country, eg. `US` |
+|                           |
+| **Observation**           |
+|                           |
+| date                      | DATE         | Date that an individual measurement was taken |
+| start_time                | TIMESTAMP    | Start time of the individual measurement |
+| end_time                  | TIMESTAMP    | End time of the individual measurement |
+| retries                   | INTEGER      | Number of times this scan was retried in a measurement |
+| measurement_id            | STRING       | A uuid which is the same for observations which are part of the same measurement. </br> If there are 5 retries of a scan they will all have the same id. </br> eg. `a08df2fe70d54092916b8df87e330f47` |
+| sent                      | STRING       | The content sent over the wire, eg. `GET / HTTP/1.1 Host: example.com` |
+| error                     | STRING       | Any error, eg. `Network Timeout` |
+|                           |
+| **Received Fields**       |              | :warning: These fields differ between scan types |
+|                           |
+| received_status           | STRING       | In Echo/Discard, any content received on the wire, eg. `HTTP/1.1 403 Forbidden` </br> In the HTTP/S, the http response status, eg. `301 Moved Permanently` |
+| received_body             | STRING       | The HTTP response body </br> eg. `<HTML><HEAD>\n<TITLE>Access Denied</TITLE>\n</HEAD></HTML>` </br> :warning: only present in HTTP/S tables |
+| received_headers          | STRING ARRAY | Each HTTP header in the response eg. `Content-Type: text/html` </br> :warning: only present in HTTP/S tables |
+| received_tls_version      | INTEGER      | The TLS version number eg. `771` (meaning TLS 1.2) </br> :warning: only present in HTTPS tables |
+| received_tls_cipher_suite | INTEGER      | The TLS cipher suite number </br> eg. `49199` (meaning TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256) </br> :warning: only present in HTTPS tables |
+| received_tls_cert         | STRING       | The TLS certificate eg. `MIIG1DCCBb...` (truncated) </br> :warning: only present in HTTPS tables |
+|                           |
+| **Analysis**              |
+|                           |
+| success                   | BOOLEAN      | Did the individual roundtrip measurement succeed? |
+| blocked                   | BOOLEAN      | Was interference detected in the overall measurement? |
+| fail_sanity               | BOOLEAN      | Was the ip being tested malfunctioning/down? |
+| stateful_block            | BOOLEAN      | Was stateful interference detected? |
+|                           |
+| **Internal**              |
+|                           |
+| source                    | STRING       | The name of the .tar.gz scan file this row came from. </br> eg. `CP_Quack-discard-2020-08-20-05-58-35` </br> Used internally and for debugging |
+
+We intend to add more columns in the future.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,0 +1,7 @@
+This folder contains [.msc files](http://www.mcternan.me.uk/mscgen/index.html)
+which specify connection diagrams for various protocols.
+
+To regnerate all image files run a command like
+
+    mscgen -i docs/diagrams/echo.msc -T svg -o docs/diagrams/echo.svg
+

--- a/docs/diagrams/discard.msc
+++ b/docs/diagrams/discard.msc
@@ -1,0 +1,10 @@
+msc {
+  probe,remote;
+
+  probe box probe [label="Initial Test Setup"];
+  probe=>remote [ label = "Establish TCP Connection" ];
+  probe=>remote [ label = "Write HTTP Request" ];
+  probe<=remote [ label = "Read Response" ];
+  probe box probe [label="Validate response content is empty"];
+  probe box probe [label="Test Complete"];
+}

--- a/docs/diagrams/discard.svg
+++ b/docs/diagrams/discard.svg
@@ -1,0 +1,77 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+ "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+ width="600px" height="190px"
+ viewBox="0 0 600 190"
+ xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges"
+ stroke-width="1" text-rendering="geometricPrecision">
+<polygon fill="white" points="133,7 165,7 165,16 133,16"/>
+<text x="150" y="16" textLength="31" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+probe
+</text>
+<polygon fill="white" points="430,7 468,7 468,16 430,16"/>
+<text x="450" y="16" textLength="37" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+remote
+</text>
+<line x1="150" y1="22" x2="150" y2="50" stroke="black"/>
+<line x1="450" y1="22" x2="450" y2="50" stroke="black"/>
+<polygon fill="white" points="8,22 292,22 292,44 8,44"/>
+<line x1="8" y1="22" x2="292" y2="22" stroke="black"/>
+<line x1="8" y1="44" x2="292" y2="44" stroke="black"/>
+<line x1="8" y1="22" x2="8" y2="44" stroke="black"/>
+<line x1="292" y1="22" x2="292" y2="44" stroke="black"/>
+<polygon fill="white" points="104,29 195,29 195,38 104,38"/>
+<text x="105" y="38" textLength="89" font-family="Helvetica" font-size="12" fill="black">
+Initial Test Setup
+</text>
+<line x1="150" y1="50" x2="150" y2="78" stroke="black"/>
+<line x1="450" y1="50" x2="450" y2="78" stroke="black"/>
+<line x1="150" y1="61" x2="450" y2="61" stroke="black"/>
+<polygon fill="black" points="450,61 440,67 440,55"/>
+<polygon fill="white" points="228,51 370,51 370,60 228,60"/>
+<text x="229" y="60" textLength="140" font-family="Helvetica" font-size="12" fill="black">
+Establish TCP Connection
+</text>
+<line x1="150" y1="78" x2="150" y2="106" stroke="black"/>
+<line x1="450" y1="78" x2="450" y2="106" stroke="black"/>
+<line x1="150" y1="89" x2="450" y2="89" stroke="black"/>
+<polygon fill="black" points="450,89 440,95 440,83"/>
+<polygon fill="white" points="243,79 356,79 356,88 243,88"/>
+<text x="244" y="88" textLength="111" font-family="Helvetica" font-size="12" fill="black">
+Write HTTP Request
+</text>
+<line x1="150" y1="106" x2="150" y2="134" stroke="black"/>
+<line x1="450" y1="106" x2="450" y2="134" stroke="black"/>
+<line x1="450" y1="117" x2="150" y2="117" stroke="black"/>
+<polygon fill="black" points="150,117 160,123 160,111"/>
+<polygon fill="white" points="255,107 343,107 343,116 255,116"/>
+<text x="256" y="116" textLength="86" font-family="Helvetica" font-size="12" fill="black">
+Read Response
+</text>
+<line x1="150" y1="134" x2="150" y2="162" stroke="black"/>
+<line x1="450" y1="134" x2="450" y2="162" stroke="black"/>
+<polygon fill="white" points="8,134 292,134 292,156 8,156"/>
+<line x1="8" y1="134" x2="292" y2="134" stroke="black"/>
+<line x1="8" y1="156" x2="292" y2="156" stroke="black"/>
+<line x1="8" y1="134" x2="8" y2="156" stroke="black"/>
+<line x1="292" y1="134" x2="292" y2="156" stroke="black"/>
+<polygon fill="white" points="55,141 244,141 244,150 55,150"/>
+<text x="56" y="150" textLength="187" font-family="Helvetica" font-size="12" fill="black">
+Validate response content is empty
+</text>
+<line x1="150" y1="162" x2="150" y2="190" stroke="black"/>
+<line x1="450" y1="162" x2="450" y2="190" stroke="black"/>
+<polygon fill="white" points="8,162 292,162 292,184 8,184"/>
+<line x1="8" y1="162" x2="292" y2="162" stroke="black"/>
+<line x1="8" y1="184" x2="292" y2="184" stroke="black"/>
+<line x1="8" y1="162" x2="8" y2="184" stroke="black"/>
+<line x1="292" y1="162" x2="292" y2="184" stroke="black"/>
+<polygon fill="white" points="109,169 189,169 189,178 109,178"/>
+<text x="110" y="178" textLength="78" font-family="Helvetica" font-size="12" fill="black">
+Test Complete
+</text>
+<line x1="150" y1="184" x2="150" y2="190" stroke="black"/>
+<line x1="450" y1="184" x2="450" y2="190" stroke="black"/>
+</svg>

--- a/docs/diagrams/echo.msc
+++ b/docs/diagrams/echo.msc
@@ -1,0 +1,10 @@
+msc {
+  probe,remote;
+
+  probe box probe [label="Initial Test Setup"];
+  probe=>remote [ label = "Establish TCP Connection" ];
+  probe=>remote [ label = "Write HTTP Request" ];
+  probe<=remote [ label = "Read Response" ];
+  probe box probe [label="Validate response content mirrors the request sent"];
+  probe box probe [label="Test Complete"];
+}

--- a/docs/diagrams/echo.svg
+++ b/docs/diagrams/echo.svg
@@ -1,0 +1,77 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+ "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+ width="600px" height="190px"
+ viewBox="0 0 600 190"
+ xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges"
+ stroke-width="1" text-rendering="geometricPrecision">
+<polygon fill="white" points="133,7 165,7 165,16 133,16"/>
+<text x="150" y="16" textLength="31" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+probe
+</text>
+<polygon fill="white" points="430,7 468,7 468,16 430,16"/>
+<text x="450" y="16" textLength="37" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+remote
+</text>
+<line x1="150" y1="22" x2="150" y2="50" stroke="black"/>
+<line x1="450" y1="22" x2="450" y2="50" stroke="black"/>
+<polygon fill="white" points="8,22 292,22 292,44 8,44"/>
+<line x1="8" y1="22" x2="292" y2="22" stroke="black"/>
+<line x1="8" y1="44" x2="292" y2="44" stroke="black"/>
+<line x1="8" y1="22" x2="8" y2="44" stroke="black"/>
+<line x1="292" y1="22" x2="292" y2="44" stroke="black"/>
+<polygon fill="white" points="104,29 195,29 195,38 104,38"/>
+<text x="105" y="38" textLength="89" font-family="Helvetica" font-size="12" fill="black">
+Initial Test Setup
+</text>
+<line x1="150" y1="50" x2="150" y2="78" stroke="black"/>
+<line x1="450" y1="50" x2="450" y2="78" stroke="black"/>
+<line x1="150" y1="61" x2="450" y2="61" stroke="black"/>
+<polygon fill="black" points="450,61 440,67 440,55"/>
+<polygon fill="white" points="228,51 370,51 370,60 228,60"/>
+<text x="229" y="60" textLength="140" font-family="Helvetica" font-size="12" fill="black">
+Establish TCP Connection
+</text>
+<line x1="150" y1="78" x2="150" y2="106" stroke="black"/>
+<line x1="450" y1="78" x2="450" y2="106" stroke="black"/>
+<line x1="150" y1="89" x2="450" y2="89" stroke="black"/>
+<polygon fill="black" points="450,89 440,95 440,83"/>
+<polygon fill="white" points="243,79 356,79 356,88 243,88"/>
+<text x="244" y="88" textLength="111" font-family="Helvetica" font-size="12" fill="black">
+Write HTTP Request
+</text>
+<line x1="150" y1="106" x2="150" y2="134" stroke="black"/>
+<line x1="450" y1="106" x2="450" y2="134" stroke="black"/>
+<line x1="450" y1="117" x2="150" y2="117" stroke="black"/>
+<polygon fill="black" points="150,117 160,123 160,111"/>
+<polygon fill="white" points="255,107 343,107 343,116 255,116"/>
+<text x="256" y="116" textLength="86" font-family="Helvetica" font-size="12" fill="black">
+Read Response
+</text>
+<line x1="150" y1="134" x2="150" y2="162" stroke="black"/>
+<line x1="450" y1="134" x2="450" y2="162" stroke="black"/>
+<polygon fill="white" points="8,134 292,134 292,156 8,156"/>
+<line x1="8" y1="134" x2="292" y2="134" stroke="black"/>
+<line x1="8" y1="156" x2="292" y2="156" stroke="black"/>
+<line x1="8" y1="134" x2="8" y2="156" stroke="black"/>
+<line x1="292" y1="134" x2="292" y2="156" stroke="black"/>
+<polygon fill="white" points="14,141 285,141 285,150 14,150"/>
+<text x="15" y="150" textLength="269" font-family="Helvetica" font-size="12" fill="black">
+Validate response content mirrors the request sent
+</text>
+<line x1="150" y1="162" x2="150" y2="190" stroke="black"/>
+<line x1="450" y1="162" x2="450" y2="190" stroke="black"/>
+<polygon fill="white" points="8,162 292,162 292,184 8,184"/>
+<line x1="8" y1="162" x2="292" y2="162" stroke="black"/>
+<line x1="8" y1="184" x2="292" y2="184" stroke="black"/>
+<line x1="8" y1="162" x2="8" y2="184" stroke="black"/>
+<line x1="292" y1="162" x2="292" y2="184" stroke="black"/>
+<polygon fill="white" points="109,169 189,169 189,178 109,178"/>
+<text x="110" y="178" textLength="78" font-family="Helvetica" font-size="12" fill="black">
+Test Complete
+</text>
+<line x1="150" y1="184" x2="150" y2="190" stroke="black"/>
+<line x1="450" y1="184" x2="450" y2="190" stroke="black"/>
+</svg>

--- a/docs/diagrams/http.msc
+++ b/docs/diagrams/http.msc
@@ -1,0 +1,11 @@
+msc {
+  probe,remote;
+
+  probe box probe [label="Initial Test Setup"];
+  probe=>remote [ label = "Establish TCP Connection" ];
+  probe=>remote [ label = "Write HTTP Request" ];
+  probe<=remote [ label = "Read Response" ];
+  probe box probe [label="Validate HTTP response"];
+  probe box probe [label="Validate response content matches the control"];
+  probe box probe [label="Test Complete"];
+}

--- a/docs/diagrams/http.svg
+++ b/docs/diagrams/http.svg
@@ -1,0 +1,88 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+ "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+ width="600px" height="218px"
+ viewBox="0 0 600 218"
+ xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges"
+ stroke-width="1" text-rendering="geometricPrecision">
+<polygon fill="white" points="133,7 165,7 165,16 133,16"/>
+<text x="150" y="16" textLength="31" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+probe
+</text>
+<polygon fill="white" points="430,7 468,7 468,16 430,16"/>
+<text x="450" y="16" textLength="37" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+remote
+</text>
+<line x1="150" y1="22" x2="150" y2="50" stroke="black"/>
+<line x1="450" y1="22" x2="450" y2="50" stroke="black"/>
+<polygon fill="white" points="8,22 292,22 292,44 8,44"/>
+<line x1="8" y1="22" x2="292" y2="22" stroke="black"/>
+<line x1="8" y1="44" x2="292" y2="44" stroke="black"/>
+<line x1="8" y1="22" x2="8" y2="44" stroke="black"/>
+<line x1="292" y1="22" x2="292" y2="44" stroke="black"/>
+<polygon fill="white" points="104,29 195,29 195,38 104,38"/>
+<text x="105" y="38" textLength="89" font-family="Helvetica" font-size="12" fill="black">
+Initial Test Setup
+</text>
+<line x1="150" y1="50" x2="150" y2="78" stroke="black"/>
+<line x1="450" y1="50" x2="450" y2="78" stroke="black"/>
+<line x1="150" y1="61" x2="450" y2="61" stroke="black"/>
+<polygon fill="black" points="450,61 440,67 440,55"/>
+<polygon fill="white" points="228,51 370,51 370,60 228,60"/>
+<text x="229" y="60" textLength="140" font-family="Helvetica" font-size="12" fill="black">
+Establish TCP Connection
+</text>
+<line x1="150" y1="78" x2="150" y2="106" stroke="black"/>
+<line x1="450" y1="78" x2="450" y2="106" stroke="black"/>
+<line x1="150" y1="89" x2="450" y2="89" stroke="black"/>
+<polygon fill="black" points="450,89 440,95 440,83"/>
+<polygon fill="white" points="243,79 356,79 356,88 243,88"/>
+<text x="244" y="88" textLength="111" font-family="Helvetica" font-size="12" fill="black">
+Write HTTP Request
+</text>
+<line x1="150" y1="106" x2="150" y2="134" stroke="black"/>
+<line x1="450" y1="106" x2="450" y2="134" stroke="black"/>
+<line x1="450" y1="117" x2="150" y2="117" stroke="black"/>
+<polygon fill="black" points="150,117 160,123 160,111"/>
+<polygon fill="white" points="255,107 343,107 343,116 255,116"/>
+<text x="256" y="116" textLength="86" font-family="Helvetica" font-size="12" fill="black">
+Read Response
+</text>
+<line x1="150" y1="134" x2="150" y2="162" stroke="black"/>
+<line x1="450" y1="134" x2="450" y2="162" stroke="black"/>
+<polygon fill="white" points="8,134 292,134 292,156 8,156"/>
+<line x1="8" y1="134" x2="292" y2="134" stroke="black"/>
+<line x1="8" y1="156" x2="292" y2="156" stroke="black"/>
+<line x1="8" y1="134" x2="8" y2="156" stroke="black"/>
+<line x1="292" y1="134" x2="292" y2="156" stroke="black"/>
+<polygon fill="white" points="83,141 216,141 216,150 83,150"/>
+<text x="84" y="150" textLength="131" font-family="Helvetica" font-size="12" fill="black">
+Validate HTTP response
+</text>
+<line x1="150" y1="162" x2="150" y2="190" stroke="black"/>
+<line x1="450" y1="162" x2="450" y2="190" stroke="black"/>
+<polygon fill="white" points="8,162 292,162 292,184 8,184"/>
+<line x1="8" y1="162" x2="292" y2="162" stroke="black"/>
+<line x1="8" y1="184" x2="292" y2="184" stroke="black"/>
+<line x1="8" y1="162" x2="8" y2="184" stroke="black"/>
+<line x1="292" y1="162" x2="292" y2="184" stroke="black"/>
+<polygon fill="white" points="25,169 274,169 274,178 25,178"/>
+<text x="26" y="178" textLength="247" font-family="Helvetica" font-size="12" fill="black">
+Validate response content matches the control
+</text>
+<line x1="150" y1="190" x2="150" y2="218" stroke="black"/>
+<line x1="450" y1="190" x2="450" y2="218" stroke="black"/>
+<polygon fill="white" points="8,190 292,190 292,212 8,212"/>
+<line x1="8" y1="190" x2="292" y2="190" stroke="black"/>
+<line x1="8" y1="212" x2="292" y2="212" stroke="black"/>
+<line x1="8" y1="190" x2="8" y2="212" stroke="black"/>
+<line x1="292" y1="190" x2="292" y2="212" stroke="black"/>
+<polygon fill="white" points="109,197 189,197 189,206 109,206"/>
+<text x="110" y="206" textLength="78" font-family="Helvetica" font-size="12" fill="black">
+Test Complete
+</text>
+<line x1="150" y1="212" x2="150" y2="218" stroke="black"/>
+<line x1="450" y1="212" x2="450" y2="218" stroke="black"/>
+</svg>

--- a/docs/diagrams/https.msc
+++ b/docs/diagrams/https.msc
@@ -1,0 +1,12 @@
+msc {
+  probe,remote;
+
+  probe box probe [label="Initial Test Setup"];
+  probe=>remote [ label = "Establish TCP Connection" ];
+  probe=>remote [ label = "Establish TLS Connection" ];
+  probe=>remote [ label = "Write HTTP Request" ];
+  probe<=remote [ label = "Read Response" ];
+  probe box probe [label="Validate HTTP response"];
+  probe box probe [label="Validate response content matches the control"];
+  probe box probe [label="Test Complete"];
+}

--- a/docs/diagrams/https.svg
+++ b/docs/diagrams/https.svg
@@ -1,0 +1,96 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+ "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+ width="600px" height="246px"
+ viewBox="0 0 600 246"
+ xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges"
+ stroke-width="1" text-rendering="geometricPrecision">
+<polygon fill="white" points="133,7 165,7 165,16 133,16"/>
+<text x="150" y="16" textLength="31" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+probe
+</text>
+<polygon fill="white" points="430,7 468,7 468,16 430,16"/>
+<text x="450" y="16" textLength="37" font-family="Helvetica" font-size="12" fill="black" text-anchor="middle">
+
+remote
+</text>
+<line x1="150" y1="22" x2="150" y2="50" stroke="black"/>
+<line x1="450" y1="22" x2="450" y2="50" stroke="black"/>
+<polygon fill="white" points="8,22 292,22 292,44 8,44"/>
+<line x1="8" y1="22" x2="292" y2="22" stroke="black"/>
+<line x1="8" y1="44" x2="292" y2="44" stroke="black"/>
+<line x1="8" y1="22" x2="8" y2="44" stroke="black"/>
+<line x1="292" y1="22" x2="292" y2="44" stroke="black"/>
+<polygon fill="white" points="104,29 195,29 195,38 104,38"/>
+<text x="105" y="38" textLength="89" font-family="Helvetica" font-size="12" fill="black">
+Initial Test Setup
+</text>
+<line x1="150" y1="50" x2="150" y2="78" stroke="black"/>
+<line x1="450" y1="50" x2="450" y2="78" stroke="black"/>
+<line x1="150" y1="61" x2="450" y2="61" stroke="black"/>
+<polygon fill="black" points="450,61 440,67 440,55"/>
+<polygon fill="white" points="228,51 370,51 370,60 228,60"/>
+<text x="229" y="60" textLength="140" font-family="Helvetica" font-size="12" fill="black">
+Establish TCP Connection
+</text>
+<line x1="150" y1="78" x2="150" y2="106" stroke="black"/>
+<line x1="450" y1="78" x2="450" y2="106" stroke="black"/>
+<line x1="150" y1="89" x2="450" y2="89" stroke="black"/>
+<polygon fill="black" points="450,89 440,95 440,83"/>
+<polygon fill="white" points="229,79 369,79 369,88 229,88"/>
+<text x="230" y="88" textLength="138" font-family="Helvetica" font-size="12" fill="black">
+Establish TLS Connection
+</text>
+<line x1="150" y1="106" x2="150" y2="134" stroke="black"/>
+<line x1="450" y1="106" x2="450" y2="134" stroke="black"/>
+<line x1="150" y1="117" x2="450" y2="117" stroke="black"/>
+<polygon fill="black" points="450,117 440,123 440,111"/>
+<polygon fill="white" points="243,107 356,107 356,116 243,116"/>
+<text x="244" y="116" textLength="111" font-family="Helvetica" font-size="12" fill="black">
+Write HTTP Request
+</text>
+<line x1="150" y1="134" x2="150" y2="162" stroke="black"/>
+<line x1="450" y1="134" x2="450" y2="162" stroke="black"/>
+<line x1="450" y1="145" x2="150" y2="145" stroke="black"/>
+<polygon fill="black" points="150,145 160,151 160,139"/>
+<polygon fill="white" points="255,135 343,135 343,144 255,144"/>
+<text x="256" y="144" textLength="86" font-family="Helvetica" font-size="12" fill="black">
+Read Response
+</text>
+<line x1="150" y1="162" x2="150" y2="190" stroke="black"/>
+<line x1="450" y1="162" x2="450" y2="190" stroke="black"/>
+<polygon fill="white" points="8,162 292,162 292,184 8,184"/>
+<line x1="8" y1="162" x2="292" y2="162" stroke="black"/>
+<line x1="8" y1="184" x2="292" y2="184" stroke="black"/>
+<line x1="8" y1="162" x2="8" y2="184" stroke="black"/>
+<line x1="292" y1="162" x2="292" y2="184" stroke="black"/>
+<polygon fill="white" points="83,169 216,169 216,178 83,178"/>
+<text x="84" y="178" textLength="131" font-family="Helvetica" font-size="12" fill="black">
+Validate HTTP response
+</text>
+<line x1="150" y1="190" x2="150" y2="218" stroke="black"/>
+<line x1="450" y1="190" x2="450" y2="218" stroke="black"/>
+<polygon fill="white" points="8,190 292,190 292,212 8,212"/>
+<line x1="8" y1="190" x2="292" y2="190" stroke="black"/>
+<line x1="8" y1="212" x2="292" y2="212" stroke="black"/>
+<line x1="8" y1="190" x2="8" y2="212" stroke="black"/>
+<line x1="292" y1="190" x2="292" y2="212" stroke="black"/>
+<polygon fill="white" points="25,197 274,197 274,206 25,206"/>
+<text x="26" y="206" textLength="247" font-family="Helvetica" font-size="12" fill="black">
+Validate response content matches the control
+</text>
+<line x1="150" y1="218" x2="150" y2="246" stroke="black"/>
+<line x1="450" y1="218" x2="450" y2="246" stroke="black"/>
+<polygon fill="white" points="8,218 292,218 292,240 8,240"/>
+<line x1="8" y1="218" x2="292" y2="218" stroke="black"/>
+<line x1="8" y1="240" x2="292" y2="240" stroke="black"/>
+<line x1="8" y1="218" x2="8" y2="240" stroke="black"/>
+<line x1="292" y1="218" x2="292" y2="240" stroke="black"/>
+<polygon fill="white" points="109,225 189,225 189,234 109,234"/>
+<text x="110" y="234" textLength="78" font-family="Helvetica" font-size="12" fill="black">
+Test Complete
+</text>
+<line x1="150" y1="240" x2="150" y2="246" stroke="black"/>
+<line x1="450" y1="240" x2="450" y2="246" stroke="black"/>
+</svg>

--- a/docs/merged_reduced_scans_table.md
+++ b/docs/merged_reduced_scans_table.md
@@ -1,0 +1,123 @@
+# Reduced Table
+
+This table is actually a view joining two tables, in order to read over less
+data with every request.
+
+These tables are created by the script
+[merged_reduced_scans.sql](../table/queries/merged_reduced_scans.sql).
+
+## Table names
+
+### View
+
+- firehook-censoredplanet.derived.merged_reduced_scans
+
+### Sub-tables
+
+- `firehook-censoredplanet.derived.merged_reduced_scans_no_as`
+- `firehook-censoredplanet.derived.merged_net_as`
+
+These two tables are joined on their `date` and `netblock` fields to create the
+view.
+
+## Partitioning and Clustering
+
+The sub-tables are time-partitioned along the `date` field.
+
+`firehook-censoredplanet.merged_reduced_scans` is clustered along the `netblock`
+field.
+
+`firehook-censoredplanet.merged_net_as` is clustered along the `country`,
+`domains` and then `netblock` fields.
+
+## Table Format
+
+Reduced Scans
+
+| Field Name | Type    | Contains |
+| ---------- | ------- | -------- |
+| date       | DATE    | Date that an individual measurement was taken |
+| domain     | STRING  | The domain being tested, eg. `example.com` |
+| country    | STRING  | Autonomous system country, eg. `US`  |
+| netblock   | STRING  | Netblock of the IP, eg. `1.1.1.0/24`  |
+| asn        | INTEGER | Autonomous system number, eg. `13335` |
+| as_name    | STRING  | Autonomous system long name, eg. `Cloudflare, Inc.` |
+| result     | STRING  | `null` (meaning success) or error returned. eg. `Incorrect web response: status lines don't match`. Errors come either from the probe system, or directly from [Go's net package](https://golang.org/pkg/net/) |
+| error      | STRING  | An error classification, explained below. eg `read/timeout` |
+| count      | INTEGER | How many measurements fit the exact pattern of this row? |
+
+## Error Classification
+
+The `error` field classifies the result of a test into an enumeration of the different types of high-level errors. Error strings are of the format `stage/error_class`. For example `read/timeout` means the test received a TCP timeout during the read stage. `final/success` means a test finished successfully.
+
+### Stages
+
+Stages are listed here in order. If a test reaches a later step like `content` then it successfully passed the earlier steps like `dial` and `read`. 
+
+| Stage       | Explanation |
+| ----------- | ----------- |
+| setup       | The initial setup phase for the test (mustering resources, opening ports, etc.) |
+| dial        | The initial TCP dial connection to the remote |
+| tls         | The TLS handshake. `HTTPS` only. The [SNI header](https://en.wikipedia.org/wiki/Server_Name_Indication) containing the test domain is sent in this stage |
+| write       | Writing to the remote. For non-`HTTPS` tests this is where the domain is sent. |
+| read        | Reading from the remote |
+| http        | Verification of HTTP headers. `HTTP/S` only |
+| content     | Verification that the returned content matches the expected content. These are the most common types of errors and represent things like blockpages. |
+| final       | Reaching the final stage without encountering any problems in the previous stages. |
+| unknown     | The stage is not known. Usually these are new errors which should be investigated and classified  |
+
+#### Stages per Probe
+
+Not all tests include every stage depending on the type of test. For example since the Echo protocol does not involve TLS Echo tests will never fail with errors classified as `tls`. Here are the stages for each test type.
+
+##### Discard
+
+![discard connection diagram](diagrams/discard.svg)
+
+##### Echo
+
+![echo connection diagram](diagrams/echo.svg)
+
+##### HTTP
+
+![http connection diagram](diagrams/http.svg)
+
+##### HTTPS
+
+![https connection diagram](diagrams/https.svg)
+
+### Error Classes
+
+Basic errors represent simplest types of errors, as well as the `success` case (no error detected).
+
+Protocol errors are similar but not identical to the Network Error Logging standard's [Predefined Network Error Types](https://www.w3.org/TR/network-error-logging/#predefined-network-error-types). These errors may represent normal network failures and noise, but they may also expose interference by a middlebox to disrupt a connection. For example China and Iran are both known to use [TCP Reset Attacks](https://en.wikipedia.org/wiki/TCP_reset_attack) as a censorship method.
+
+Mismatch Errors are used when the connection is successful, but the content received does not match the content expected. This can happen in the case of blockpages, remote servers with unusual behavior, or complicated CDN networks serving many sites.
+
+| Error Class             | Explanation |
+| ----------------------- | ----------- |
+|                         |
+| **Basic Errors**        |
+|                         |
+| success                 | The test completed successfully and no interference was detected |
+| system                  | There was a test system failure, rendering the test invalid |
+| unknown                 | The class of the error is not known. Usually these are new errors which should be investigated and classified |
+|                         |
+| **Protocol Errors**     | There were errors in the connection protocol |
+|                         |
+| ip.network_unreachable  | The network was unreachable |
+| ip.host_no_route        | No route to the host could be found |
+| timeout                 | The connection timed out. Could indicate packets being dropped by a middlebox |
+| tcp.refused             | The TCP connection was refused by the server |
+| tcp.reset               | The TCP connection was reset. Could indicate an inserted `RST` packet |
+| tls.failed              | The TLS connection failed, usually due to a TLS protocol error |
+| http.invalid            | The HTTP response could not be parsed. Possibly because the response has a content-length mismatch, has improper encoding, or other conditions |
+| http.empty              | Received no content when HTTP content was expected |
+| http.truncated_response | The HTTP response content was unexpectedly truncated |
+|                         |
+| **Mismatch Errors**     | The connection completed successfully, but the content returned didn't match the content expected for the domain. |
+|                         |
+| response_mismatch       | Received a different response from the one expected. </br> For Discard no response is expected and any response is a mismatch, </br> for Echo a mirrored response is expected and anything else is a mismatch. |
+| status_mismatch         | The HTTP status code doesn't match, eg. `403` instead of `200` |
+| body_mismatch           | The HTTP body didn't match, potentially a blockpage |
+| tls_mismatch            | An element of the TLS connection (certificate, cipher suite, or TLS version) didn't match |

--- a/docs/merged_scans_table.md
+++ b/docs/merged_scans_table.md
@@ -1,0 +1,33 @@
+# Merged Table
+
+This table contains data from all 4 scan types together in one place.
+
+This table is created by the script
+[merged_scans.sql](../table/queries/merged_scans.sql).
+
+## Table Name
+
+- `firehook-censoredplanet.derived.merged_error_scans`
+
+## Partitioning and Clustering
+
+The tables are time-partitioned along the `date` field.
+
+The tables are clustered along the `source`, `country`, `domain`, and then
+`result` fields.
+
+## Table format
+
+| Field Name | Type    | Contains |
+| ---------- | ------- | -------- |
+| date       | DATE    | Date that an individual measurement was taken |
+| domain     | STRING  | The domain being tested, eg. `example.com` |
+| country    | STRING  | Autonomous system country, eg. `US`  |
+| asn        | INTEGER | Autonomous system number, eg. `13335` |
+| as_name    | STRING  | Autonomous system short name, eg. `CLOUDFLARENET` |
+| ip         | STRING  | The ip address of the server being tested, eg. `1.1.1.1` |
+| netblock   | STRING  | Netblock of the IP, eg. `1.1.1.0/24` |
+| as_class   | STRING  | The type of AS eg. `Transit/Access`, `Content` (for CDNs) or `Enterprise`  |
+| source     | STRING  | The type of measurement, one of `ECHO`, `DISCARD`, `HTTP`, `HTTPS` |
+| result     | STRING  | The source type, followed by the `: null` (meaning success) or error returned. eg. `ECHO: null`, `HTTPS: Incorrect web response: status lines don't match`, `HTTP: Get http://[IP]: net/http: request canceled (Client.Timeout exceeded while awaiting headers)` `DISCARD: Received response` |
+| count      | INTEGER | How many measurements fit the exact pattern of this row? |

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -1,189 +1,20 @@
 # Bigquery Tables
 
-## Base Tables
+## Base tables
 
-These tables are created using the original censored planet json data, plus some
-[additional data sources](../pipeline/metadata/).
+These tables are directly derived from the raw Censored Planet data. They are
+used as a base for further analysis tables.
 
-#### Table names
-
-There is one table for each scan type.
-
-- `firehook-censoredplanet:base.echo_scan`
-- `firehook-censoredplanet:base.discard_scan`
-- `firehook-censoredplanet:base.http_scan`
-- `firehook-censoredplanet:base.https_scan`
-
-#### Partitioning and Clustering
-
-The tables are time-partitioned along the `date` field.
-
-The tables are clustered along the `country` and then `asn` fields.
-
-#### Original Data Format
-
-The Censored Planet data is stored in .json files with one measurement per line.
-The measurements look like this:
-
-```
-{ "Server": "1.1.1.1",
-  "Keyword": "example.com",
-  "Retries": 4,
-  "Results": [
-    {
-      "Sent": "GET / HTTP/1.1 Host: example.com",
-      "Received": "HTTP/1.1 503 Service Unavailable",
-      "Success": false,
-      "Error": "Incorrect echo response",
-      "StartTime": "2020-04-29T07:29:46.139500633-04:00",
-      "EndTime": "2020-04-29T07:29:46.490678827-04:00"
-    },
-    ...
-  ],
-  "Blocked": true,
-  "FailSanity": false,
-  "StatefulBlock": false
-}
-```
-
-#### Table Format
-
-The json data is processed into a flat table format which looks like this.
-
-| Field Name                | Type         | Contains |
-| ------------------------- | ------------ | -------- |
-|                           |
-| **Measured Domain**       |
-|                           |
-| domain                    | STRING       | The domain being tested, eg. `example.com` |
-|                           |
-| **Vantage Point Server**  |
-|                           |
-| ip                        | STRING       | The ip address of the server being tested, eg. `1.1.1.1` |
-| netblock                  | STRING       | Netblock of the IP, eg. `1.1.1.0/24` |
-| asn                       | INTEGER      | Autonomous system number, eg. `13335` |
-| as_name                   | STRING       | Autonomous system short name, eg. `CLOUDFLARENET` |
-| as_full_name              | STRING       | Autonomous system long name, eg. `Cloudflare, Inc.` |
-| as_class                  | STRING       | The type of AS eg. `Transit/Access`, `Content` (for CDNs) or `Enterprise` |
-| country                   | STRING       | Autonomous system country, eg. `US` |
-|                           |
-| **Observation**           |
-|                           |
-| date                      | DATE         | Date that an individual measurement was taken |
-| start_time                | TIMESTAMP    | Start time of the individual measurement |
-| end_time                  | TIMESTAMP    | End time of the individual measurement |
-| retries                   | INTEGER      | Number of times this scan was retried in a measurement |
-| measurement_id            | STRING       | A uuid which is the same for observations which are part of the same measurement. </br> If there are 5 retries of a scan they will all have the same id. </br> eg. `a08df2fe70d54092916b8df87e330f47` |
-| sent                      | STRING       | The content sent over the wire, eg. `GET / HTTP/1.1 Host: example.com` |
-| error                     | STRING       | Any error, eg. `Network Timeout` |
-|                           |
-| **Received Fields**       |              | :warning: These fields differ between scan types |
-|                           |
-| received_status           | STRING       | In Echo/Discard, any content received on the wire, eg. `HTTP/1.1 403 Forbidden` </br> In the HTTP/S, the http response status, eg. `301 Moved Permanently` |
-| received_body             | STRING       | The HTTP response body </br> eg. `<HTML><HEAD>\n<TITLE>Access Denied</TITLE>\n</HEAD></HTML>` </br> :warning: only present in HTTP/S tables |
-| received_headers          | STRING ARRAY | Each HTTP header in the response eg. `Content-Type: text/html` </br> :warning: only present in HTTP/S tables |
-| received_tls_version      | INTEGER      | The TLS version number eg. `771` (meaning TLS 1.2) </br> :warning: only present in HTTPS tables |
-| received_tls_cipher_suite | INTEGER      | The TLS cipher suite number </br> eg. `49199` (meaning TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256) </br> :warning: only present in HTTPS tables |
-| received_tls_cert         | STRING       | The TLS certificate eg. `MIIG1DCCBb...` (truncated) </br> :warning: only present in HTTPS tables |
-|                           |
-| **Analysis**              |
-|                           |
-| success                   | BOOLEAN      | Did the individual roundtrip measurement succeed? |
-| blocked                   | BOOLEAN      | Was interference detected in the overall measurement? |
-| fail_sanity               | BOOLEAN      | Was the ip being tested malfunctioning/down? |
-| stateful_block            | BOOLEAN      | Was stateful interference detected? |
-|                           |
-| **Internal**              |
-|                           |
-| source                    | STRING       | The name of the .tar.gz scan file this row came from. </br> eg. `CP_Quack-discard-2020-08-20-05-58-35` </br> Used internally and for debugging |
-
-We intend to add more columns in the future.
+- [Base Tables](base_tables.md)
 
 ## Derived Tables
 
-These tables are created from the base tables. They drop some data but also do
-some common pre-processing and are partitioned, making them faster, easier and
-less expensive to use.
+These tables are created from the base tables. They drop some data and also do
+some common pre-processing, making them faster, easier and less expensive to
+use.
 
-### Merged Table
-
-This table contains data from all 4 scan types together in one place.
-
-This table is created by the script
-[merged_scans.sql](../table/queries/merged_scans.sql).
-
-#### Table Name
-
-- `firehook-censoredplanet.derived.merged_error_scans`
-
-#### Partitioning and Clustering
-
-The tables are time-partitioned along the `date` field.
-
-The tables are clustered along the `source`, `country`, `domain`, and then
-`result` fields.
-
-#### Table format
-
-| Field Name | Type    | Contains |
-| ---------- | ------- | -------- |
-| date       | DATE    | Date that an individual measurement was taken |
-| domain     | STRING  | The domain being tested, eg. `example.com` |
-| country    | STRING  | Autonomous system country, eg. `US`  |
-| asn        | INTEGER | Autonomous system number, eg. `13335` |
-| as_name    | STRING  | Autonomous system short name, eg. `CLOUDFLARENET` |
-| ip         | STRING  | The ip address of the server being tested, eg. `1.1.1.1` |
-| netblock   | STRING  | Netblock of the IP, eg. `1.1.1.0/24` |
-| as_class   | STRING  | The type of AS eg. `Transit/Access`, `Content` (for CDNs) or `Enterprise`  |
-| source     | STRING  | The type of measurement, one of `ECHO`, `DISCARD`, `HTTP`, `HTTPS` |
-| result     | STRING  | The source type, followed by the `: null` (meaning success) or error returned. eg. `ECHO: null`, `HTTPS: Incorrect web response: status lines don't match`, `HTTP: Get http://[IP]: net/http: request canceled (Client.Timeout exceeded while awaiting headers)` `DISCARD: Received response` |
-| count      | INTEGER | How many measurements fit the exact pattern of this row? |
-
-### Reduced Table
-
-This table is actually a view joining two tables, in order to read over less
-data with every request.
-
-This table contains only HTTPS scan data.
-
-These tables are created by the script
-[https_reduced_scans.sql](../table/queries/https_reduced_scans.sql).
-
-#### Table names
-
-##### View
-
-- firehook-censoredplanet.derived.https_reduced_scans
-
-##### Joined Sub-tables
-
-- `firehook-censoredplanet.derived.https_reduced_scans_no_as`
-- `firehook-censoredplanet.derived.https_net_as`
-
-These two tables are joined on their `date` and `netblock` fields to create the
-view.
-
-#### Partitioning and Clustering
-
-The sub-tables are time-partitioned along the `date` field.
-
-`firehook-censoredplanet.https.reduced_scans` is clustered along the `netblock`
-field.
-
-`firehook-censoredplanet.https.net_as` is clustered along the `country`,
-`domains` and then `netblock` fields.
-
-#### Table Formats
-
-Reduced Scans
-
-| Field Name | Type    | Contains |
-| ---------- | ------- | -------- |
-| date       | DATE    | Date that an individual measurement was taken |
-| domain     | STRING  | The domain being tested, eg. `example.com` |
-| country    | STRING  | Autonomous system country, eg. `US`  |
-| netblock   | STRING  | Netblock of the IP, eg. `1.1.1.0/24`  |
-| asn        | INTEGER | Autonomous system number, eg. `13335` |
-| as_name    | STRING  | Autonomous system long name, eg. `Cloudflare, Inc.` |
-| result     | STRING  | The source type, followed by the `: null` (meaning success) or error returned. eg. `HTTPS: null`, `HTTPS: Incorrect web response: status lines don't match` |
-| count      | INTEGER | How many measurements fit the exact pattern of this row? |
+- [Merged Scans Table](merged_scans_table.md) This table merges the data from
+  the base tables and drops some less useful fields.
+- [Merged Reduced Scans Table](merged_reduced_scans_table.md) This table merges
+  the data from the base tables, but uses a set of subtables to reduce the
+  total amount of data read. It also includes an error analysis field.

--- a/table/queries/merged_reduced_scans.sql
+++ b/table/queries/merged_reduced_scans.sql
@@ -27,64 +27,60 @@ CREATE TEMP FUNCTION CleanError(error STRING) AS (
 # Source is one of "ECHO", "Discard, "HTTP", "HTTPS"
 #
 # Output is a string of the format "step/error_enum"
-#
-# Where step is one of (in order)
-# "setup", "dial", "tls", "write", "read", "http", "content", "final" or "unknown", 
-#
-# and error_enum is an NEL network error type string
-# https://www.w3.org/TR/network-error-logging/#predefined-network-error-types
-# or one of "invalid", "unknown", "tcp.no_route"
-# or a string like "*_mismatch" indicating a successful connection but unexpected content.
+# Documentation of this enum is at
+# https://github.com/Jigsaw-Code/censoredplanet-analysis/blob/master/docs/tables.md#error-classification
 CREATE TEMP FUNCTION ClassifyError(error STRING, source STRING) AS (
   CASE
     # Success
     WHEN (error is NULL OR error = "") then "final/success"
 
     # System failures
-    WHEN ENDS_WITH(error, "address already in use") THEN "setup/invalid"
-    WHEN ENDS_WITH(error, "protocol error") THEN "setup/invalid"
-    WHEN ENDS_WITH(error, "protocol not available") THEN "setup/invalid" # ipv4 vs 6 error
-    WHEN ENDS_WITH(error, "too many open files") THEN "setup/invalid"
+    WHEN ENDS_WITH(error, "address already in use") THEN "setup/system"
+    WHEN ENDS_WITH(error, "protocol error") THEN "setup/system"
+    WHEN ENDS_WITH(error, "protocol not available") THEN "setup/system" # ipv4 vs 6 error
+    WHEN ENDS_WITH(error, "too many open files") THEN "setup/system"
 
     # Dial failures
-    WHEN ENDS_WITH(error, "network is unreachable") THEN "dial/tcp.address_unreachable"
-    WHEN ENDS_WITH(error, "no route to host") THEN "dial/tcp.no_route"
+    WHEN ENDS_WITH(error, "network is unreachable") THEN "dial/ip.network_unreachable"
+    WHEN ENDS_WITH(error, "no route to host") THEN "dial/ip.host_no_route"
     WHEN ENDS_WITH(error, "connection refused") THEN "dial/tcp.refused"
-    WHEN ENDS_WITH(error, "context deadline exceeded") THEN "dial/tcp.timed_out"
-    WHEN ENDS_WITH(error, "connect: connection timed out") THEN "dial/tcp.timed_out"
+    WHEN ENDS_WITH(error, "context deadline exceeded") THEN "dial/timeout"
+    WHEN ENDS_WITH(error, "connect: connection timed out") THEN "dial/timeout"
     WHEN STARTS_WITH(error, "connection reset by peer") THEN "dial/tcp.reset" #no read: or write: prefix in error
     WHEN ENDS_WITH(error, "connect: connection reset by peer") THEN "dial/tcp.reset"
     WHEN ENDS_WITH(error, "getsockopt: connection reset by peer") THEN "dial/tcp.reset"
 
     # TLS failures
-    WHEN REGEXP_CONTAINS(error, "tls:") THEN "tls/tls.protocol.error"
+    WHEN REGEXP_CONTAINS(error, "tls:") THEN "tls/tls.failed"
     WHEN REGEXP_CONTAINS(error, "remote error:") THEN "tls/tls.failed"
     WHEN REGEXP_CONTAINS(error, "local error:") THEN "tls/tls.failed"
     WHEN ENDS_WITH(error, "readLoopPeekFailLocked: <nil>") THEN "tls/tls.failed"
-    WHEN ENDS_WITH(error, "missing ServerKeyExchange message") THEN "tls/tls.protocol.error"
-    WHEN ENDS_WITH(error, "no mutual cipher suite") THEN "tls/tls.protocol.error"
+    WHEN ENDS_WITH(error, "missing ServerKeyExchange message") THEN "tls/tls.failed"
+    WHEN ENDS_WITH(error, "no mutual cipher suite") THEN "tls/tls.failed"
 
     # Write failures
     WHEN ENDS_WITH(error, "write: connection reset by peer") THEN "write/tcp.reset"
-    WHEN ENDS_WITH(error, "write: broken pipe") THEN "write/invalid"
+    WHEN ENDS_WITH(error, "write: broken pipe") THEN "write/system"
 
     # Read failures
-    WHEN REGEXP_CONTAINS(error, "request canceled") THEN "read/tcp.timed_out"
-    WHEN ENDS_WITH(error, "i/o timeout") THEN "read/tcp.timed_out"
-    WHEN ENDS_WITH(error, "shutdown: transport endpoint is not connected") THEN "read/invalid"
+    WHEN REGEXP_CONTAINS(error, "request canceled") THEN "read/timeout"
+    WHEN ENDS_WITH(error, "i/o timeout") THEN "read/timeout"
+    WHEN ENDS_WITH(error, "shutdown: transport endpoint is not connected") THEN "read/system"
     # TODO: for HTTPS this error could potentially also be SNI blocking in the tls stage
     # find a way to diffentiate this case.
     WHEN ENDS_WITH(error, "read: connection reset by peer") THEN "read/tcp.reset"
-    WHEN (source != "ECHO" AND REGEXP_CONTAINS(error, "EOF")) THEN "read/tcp.closed"
-    WHEN ENDS_WITH(error, "http: server closed idle connection") THEN "read/tcp.closed"
+    
 
     # HTTP content verification failures
-    WHEN ENDS_WITH(error, "trailer header without chunked transfer encoding") THEN "http/http.response.invalid"
-    WHEN ENDS_WITH(error, "response missing Location header") THEN "http/http.response.invalid"
-    WHEN REGEXP_CONTAINS(error, "bad Content-Length") THEN "http/http.response.invalid"
-    WHEN REGEXP_CONTAINS(error, "failed to parse Location header") THEN "http/http.response.invalid"
-    WHEN REGEXP_CONTAINS(error, "malformed HTTP") THEN "http/http.response.invalid"
-    WHEN REGEXP_CONTAINS(error, "malformed MIME") THEN "http/http.response.invalid"
+    WHEN (source != "ECHO" AND REGEXP_CONTAINS(error, "unexpected EOF")) THEN "read/http.truncated_response"
+    WHEN (source != "ECHO" AND REGEXP_CONTAINS(error, "EOF")) THEN "read/http.empty"
+    WHEN ENDS_WITH(error, "http: server closed idle connection") THEN "read/http.truncated_response"
+    WHEN ENDS_WITH(error, "trailer header without chunked transfer encoding") THEN "http/http.invalid"
+    WHEN ENDS_WITH(error, "response missing Location header") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "bad Content-Length") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "failed to parse Location header") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "malformed HTTP") THEN "http/http.invalid"
+    WHEN REGEXP_CONTAINS(error, "malformed MIME") THEN "http/http.invalid"
 
     # Content verification failures
     WHEN (source = "ECHO" AND ENDS_WITH(error, "EOF")) THEN "content/response_mismatch" # Echo
@@ -92,8 +88,8 @@ CREATE TEMP FUNCTION ClassifyError(error STRING, source STRING) AS (
     WHEN (error = "Received response") THEN "content/response_mismatch" # Discard
     WHEN (error = "Incorrect web response: status lines don't match") THEN "content/status_mismatch" # HTTP/S
     WHEN (error = "Incorrect web response: bodies don't match") THEN "content/body_mismatch" # HTTP/S
-    WHEN (error = "Incorrect web response: certificates don't match") THEN "content/certificate_mismatch" # HTTPS
-    WHEN (error = "Incorrect web response: cipher suites don't match") THEN "content/cipher_suite_mismatch" # HTTPS
+    WHEN (error = "Incorrect web response: certificates don't match") THEN "content/tls_mismatch" # HTTPS
+    WHEN (error = "Incorrect web response: cipher suites don't match") THEN "content/tls_mismatch" # HTTPS
     WHEN (error = "Incorrect web response: TLS versions don't match") THEN "content/tls_mismatch" # HTTPS
 
     # Unknown errors


### PR DESCRIPTION
View formatted markdown at: https://github.com/Jigsaw-Code/censoredplanet-analysis/blob/doc/docs/tables.md#error-classification.

Would appreciate your thoughts on more ways to make these docs accessible to people who have less background in network interference or are learning.